### PR TITLE
correct s3 backup managed policy ARN (no service-role/ in aws-us-gov)

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -60,7 +60,7 @@ resource "aws_iam_role_policy_attachment" "backup-s3-backups-iam-attach" {
   provider = aws.primary
 
   role       = aws_iam_role.backup-iam-role.name
-  policy_arn = "arn:${var.partition}:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForS3Backup"
+  policy_arn = "arn:aws-us-gov:iam::aws:policy/AWSBackupServiceRolePolicyForS3Backup"
 
   depends_on = [aws_iam_role.backup-iam-role]
 }


### PR DESCRIPTION
**Problem**
In v1.0.0 we attached AWS managed policy `AWSBackupServiceRolePolicyForS3Backup` using:
  arn:${var.partition}:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForS3Backup
This works in commercial AWS but fails in GovCloud because that path is not published there.

**Evidence**
GovCloud lists the policy at:
  arn:aws-us-gov:iam::aws:policy/AWSBackupServiceRolePolicyForS3Backup
(no `service-role/` segment)

**Fix**
Make the policy ARN partition-aware:
- aws-us-gov → arn:aws-us-gov:iam::aws:policy/AWSBackupServiceRolePolicyForS3Backup
- otherwise → arn:${var.partition}:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForS3Backup

**Testing**
- Deployed in us-gov-west-1 (ECSFR mgmt).
- `terraform plan/apply` succeeds; role attachment created: role = <prefix>-backup-role policy_arn = arn:aws-us-gov:iam::aws:policy/AWSBackupServiceRolePolicyForS3Backup
- Verified via `aws iam list-attached-role-policies`.

**Impact**
Unblocks S3 backups in GovCloud while preserving behavior in commercial AWS.